### PR TITLE
Migrate from Proxycurl to Apollo.io API

### DIFF
--- a/test-dry-run.js
+++ b/test-dry-run.js
@@ -1,0 +1,630 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Dry-run validation for n8n workflow JSON files.
+ * Validates structure, connections, node references, code execution, and Claude prompts.
+ * No dependencies required — run with: node test-dry-run.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function pass(label) {
+  passed++;
+  console.log(`  ✓ ${label}`);
+}
+
+function fail(label, detail) {
+  failed++;
+  const msg = detail ? `${label}: ${detail}` : label;
+  failures.push(msg);
+  console.log(`  ✗ ${msg}`);
+}
+
+function assert(condition, label, detail) {
+  if (condition) pass(label);
+  else fail(label, detail);
+}
+
+function section(title) {
+  console.log(`\n━━━ ${title} ━━━`);
+}
+
+// ─── Load workflows ─────────────────────────────────────────────────────────
+
+const DIR = __dirname;
+const WORKFLOW_FILES = [
+  'workflow-research-pipeline.json',
+  'workflow-weekly-report.json',
+];
+
+const workflows = {};
+
+section('0. File Loading');
+for (const file of WORKFLOW_FILES) {
+  const fp = path.join(DIR, file);
+  try {
+    const raw = fs.readFileSync(fp, 'utf8');
+    workflows[file] = JSON.parse(raw);
+    pass(`${file} parses as valid JSON`);
+  } catch (e) {
+    fail(`${file} parses as valid JSON`, e.message);
+    workflows[file] = null;
+  }
+}
+
+// ─── Mock data ──────────────────────────────────────────────────────────────
+
+const MOCK_APOLLO_RESOLVE = {
+  id: '5e66b6381e05b4008c8331b8',
+  name: 'Acme Corp',
+  website_url: 'http://www.acme.com',
+  linkedin_url: 'http://www.linkedin.com/company/acme',
+  primary_domain: 'acme.com',
+  industry: 'information technology & services',
+  estimated_num_employees: 500,
+};
+
+const MOCK_APOLLO_PEOPLE = {
+  total_entries: 1,
+  people: [
+    {
+      id: '63519a6d6fa6ba00019200f8',
+      first_name: 'Jane',
+      last_name: 'Doe',
+      title: 'CTO',
+      name: 'Jane Doe',
+      linkedin_url: 'https://linkedin.com/in/janedoe',
+      organization: { name: 'Acme Corp' },
+    },
+  ],
+};
+
+const MOCK_SEC_EDGAR = {
+  hits: {
+    hits: [
+      {
+        _source: {
+          form_type: '10-K',
+          file_date: '2025-06-15',
+          entity_name: 'Acme Corp',
+          file_url: '/Archives/edgar/data/123/filing.htm',
+          accession_no: '0001234-25-000001',
+        },
+      },
+    ],
+  },
+};
+
+const MOCK_FILING_HTML =
+  '<html><body>Technology investments include cloud migration and cybersecurity initiatives. ' +
+  'Information technology infrastructure modernization is underway.</body></html>';
+
+const MOCK_CLAUDE_RESPONSE = {
+  content: [
+    {
+      text: JSON.stringify({
+        company: { name: 'Acme Corp', ticker: 'ACME', website: 'acme.com' },
+        it_leaders: [
+          {
+            name: 'Jane Doe',
+            title: 'CTO',
+            linkedin_url: 'https://linkedin.com/in/janedoe',
+            key_background: 'Former VP Engineering at BigCo',
+            talking_points: ['Cloud migration expert', 'Led digital transformation'],
+          },
+        ],
+        strategic_initiatives: [
+          {
+            initiative: 'Cloud Migration',
+            description: 'Multi-year cloud migration program',
+            filing_reference: '10-K 2025',
+          },
+        ],
+        technology_themes: [
+          { theme: 'Cloud', priority: 'high', evidence: '10-K filing mentions cloud 15 times' },
+        ],
+        summary: 'Acme Corp is investing heavily in cloud and cybersecurity.',
+      }),
+    },
+  ],
+};
+
+const MOCK_CLAUDE_DELTA_RESPONSE = {
+  content: [
+    {
+      text: JSON.stringify({
+        company: 'Acme Corp',
+        week_of: '2026-01-30',
+        new_leaders: [],
+        changed_leaders: [],
+        departed_leaders: [],
+        new_filings: [],
+        new_initiatives: [],
+        updated_themes: [],
+        executive_summary: 'No significant changes this week.',
+      }),
+    },
+  ],
+};
+
+const MOCK_COMPANY_ROW = {
+  'Company Name': 'Acme Corp',
+  Ticker: 'ACME',
+  Website: 'acme.com',
+  'LinkedIn URL': '',
+  Status: '',
+  'Last Researched': '',
+};
+
+const MOCK_EXISTING_LEADERS = [
+  {
+    Company: 'Acme Corp',
+    Name: 'Jane Doe',
+    Title: 'CTO',
+    'LinkedIn URL': 'https://linkedin.com/in/janedoe',
+    'Key Background': 'Former VP Engineering at BigCo',
+    'Talking Points': 'Cloud migration expert; Led digital transformation',
+    'Date Found': '2026-01-20',
+  },
+];
+
+// ─── 1. Schema Validation ───────────────────────────────────────────────────
+
+section('1. Schema Validation');
+
+const REQUIRED_TOP_KEYS = ['name', 'nodes', 'connections', 'settings'];
+const REQUIRED_NODE_KEYS = ['id', 'name', 'type', 'position'];
+
+for (const [file, wf] of Object.entries(workflows)) {
+  if (!wf) continue;
+  const label = wf.name || file;
+
+  // Top-level keys
+  for (const key of REQUIRED_TOP_KEYS) {
+    assert(
+      wf[key] !== undefined,
+      `[${label}] has top-level key "${key}"`,
+    );
+  }
+
+  assert(Array.isArray(wf.nodes), `[${label}] "nodes" is an array`);
+  assert(
+    typeof wf.connections === 'object' && !Array.isArray(wf.connections),
+    `[${label}] "connections" is an object`,
+  );
+
+  // Node structure
+  let allNodesValid = true;
+  const badNodes = [];
+  for (const node of wf.nodes) {
+    for (const key of REQUIRED_NODE_KEYS) {
+      if (node[key] === undefined) {
+        allNodesValid = false;
+        badNodes.push(`${node.name || node.id || '?'} missing "${key}"`);
+      }
+    }
+    // Position must be array of 2 numbers
+    if (
+      !Array.isArray(node.position) ||
+      node.position.length !== 2 ||
+      typeof node.position[0] !== 'number' ||
+      typeof node.position[1] !== 'number'
+    ) {
+      allNodesValid = false;
+      badNodes.push(`${node.name || '?'} invalid position`);
+    }
+    // Type prefix
+    if (typeof node.type === 'string' && !node.type.startsWith('n8n-nodes-base.')) {
+      allNodesValid = false;
+      badNodes.push(`${node.name || '?'} type "${node.type}" missing n8n-nodes-base. prefix`);
+    }
+  }
+  assert(
+    allNodesValid,
+    `[${label}] all nodes have required fields and valid structure`,
+    badNodes.join('; '),
+  );
+}
+
+// ─── 2. Connection Graph ────────────────────────────────────────────────────
+
+section('2. Connection Graph');
+
+for (const [file, wf] of Object.entries(workflows)) {
+  if (!wf) continue;
+  const label = wf.name || file;
+  const nodeNames = new Set(wf.nodes.map((n) => n.name));
+
+  // Trigger node types
+  const TRIGGER_TYPES = [
+    'n8n-nodes-base.manualTrigger',
+    'n8n-nodes-base.googleSheetsTrigger',
+    'n8n-nodes-base.scheduleTrigger',
+  ];
+  const triggerNames = new Set(
+    wf.nodes.filter((n) => TRIGGER_TYPES.includes(n.type)).map((n) => n.name),
+  );
+
+  // Every source node in connections exists
+  let allSourcesValid = true;
+  const badSources = [];
+  for (const srcName of Object.keys(wf.connections)) {
+    if (!nodeNames.has(srcName)) {
+      allSourcesValid = false;
+      badSources.push(srcName);
+    }
+  }
+  assert(
+    allSourcesValid,
+    `[${label}] all connection source nodes exist`,
+    `missing: ${badSources.join(', ')}`,
+  );
+
+  // Every target node in connections exists
+  let allTargetsValid = true;
+  const badTargets = [];
+  for (const [srcName, outputs] of Object.entries(wf.connections)) {
+    const mainOutputs = outputs.main || [];
+    for (const outputGroup of mainOutputs) {
+      if (!Array.isArray(outputGroup)) continue;
+      for (const conn of outputGroup) {
+        if (!nodeNames.has(conn.node)) {
+          allTargetsValid = false;
+          badTargets.push(`${srcName} → ${conn.node}`);
+        }
+      }
+    }
+  }
+  assert(
+    allTargetsValid,
+    `[${label}] all connection target nodes exist`,
+    `missing: ${badTargets.join(', ')}`,
+  );
+
+  // Reachability: BFS from triggers
+  const reachable = new Set(triggerNames);
+  const queue = [...triggerNames];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    const outputs = wf.connections[current];
+    if (!outputs || !outputs.main) continue;
+    for (const outputGroup of outputs.main) {
+      if (!Array.isArray(outputGroup)) continue;
+      for (const conn of outputGroup) {
+        if (!reachable.has(conn.node)) {
+          reachable.add(conn.node);
+          queue.push(conn.node);
+        }
+      }
+    }
+  }
+
+  const unreachableNodes = [];
+  for (const node of wf.nodes) {
+    if (!triggerNames.has(node.name) && !reachable.has(node.name)) {
+      unreachableNodes.push(node.name);
+    }
+  }
+  assert(
+    unreachableNodes.length === 0,
+    `[${label}] all non-trigger nodes are reachable`,
+    `unreachable: ${unreachableNodes.join(', ')}`,
+  );
+
+  // Loop-back connects to splitInBatches
+  const splitNodes = new Set(
+    wf.nodes
+      .filter((n) => n.type === 'n8n-nodes-base.splitInBatches')
+      .map((n) => n.name),
+  );
+  const loopBackNodes = wf.nodes.filter((n) => n.type === 'n8n-nodes-base.noOp');
+  for (const lb of loopBackNodes) {
+    const conn = wf.connections[lb.name];
+    if (!conn || !conn.main) continue;
+    const targets = conn.main
+      .flat()
+      .filter(Boolean)
+      .map((c) => c.node);
+    const connectsToSplit = targets.some((t) => splitNodes.has(t));
+    assert(
+      connectsToSplit,
+      `[${label}] "${lb.name}" loops back to a splitInBatches node`,
+      `targets: ${targets.join(', ')}`,
+    );
+  }
+}
+
+// ─── 3. Node Name References ────────────────────────────────────────────────
+
+section('3. Node Name References');
+
+for (const [file, wf] of Object.entries(workflows)) {
+  if (!wf) continue;
+  const label = wf.name || file;
+  const nodeNames = new Set(wf.nodes.map((n) => n.name));
+
+  // Collect all $('...') references from the entire JSON
+  const jsonStr = JSON.stringify(wf);
+  const refPattern = /\$\('([^']+)'\)/g;
+  const allRefs = new Set();
+  let match;
+  while ((match = refPattern.exec(jsonStr)) !== null) {
+    allRefs.add(match[1]);
+  }
+
+  const missingRefs = [];
+  for (const ref of allRefs) {
+    if (!nodeNames.has(ref)) {
+      missingRefs.push(ref);
+    }
+  }
+  assert(
+    missingRefs.length === 0,
+    `[${label}] all $('NodeName') references point to existing nodes`,
+    `missing: ${missingRefs.join(', ')}`,
+  );
+
+  pass(`[${label}] found ${allRefs.size} node references, all valid`);
+}
+
+// ─── 4. Code Node Execution ─────────────────────────────────────────────────
+
+section('4. Code Node Execution');
+
+/**
+ * Build a mock $() function and $input/$json for executing code nodes.
+ * The mock returns data appropriate for the referenced node name.
+ */
+function buildMockContext(workflowName) {
+  const mockNodeData = {
+    // Research Pipeline mocks
+    'SEC EDGAR Search 10-K': MOCK_SEC_EDGAR,
+    'Fetch 10-K Filing': { data: MOCK_FILING_HTML, body: MOCK_FILING_HTML },
+    'Parse EDGAR Results': {
+      filingUrl: 'https://www.sec.gov/Archives/edgar/data/123/filing.htm',
+      filings: [
+        { form: '10-K', date: '2025-06-15', company: 'Acme Corp', url: '/Archives/edgar/data/123/filing.htm' },
+      ],
+      rawResultAvailable: true,
+    },
+    'Claude Analysis': MOCK_CLAUDE_RESPONSE,
+    'Loop Over Companies': MOCK_COMPANY_ROW,
+    'Apollo Resolve Company': MOCK_APOLLO_RESOLVE,
+    'Apollo Search IT Leaders': MOCK_APOLLO_PEOPLE,
+    'Format Results': {
+      companyName: 'Acme Corp',
+      leaderRows: [
+        {
+          Company: 'Acme Corp',
+          Name: 'Jane Doe',
+          Title: 'CTO',
+          'LinkedIn URL': 'https://linkedin.com/in/janedoe',
+          'Key Background': 'Former VP Engineering at BigCo',
+          'Talking Points': 'Cloud migration expert; Led digital transformation',
+          'Date Found': '2026-01-30',
+        },
+        {
+          Company: 'Acme Corp',
+          Name: 'John Smith',
+          Title: 'CISO',
+          'LinkedIn URL': 'https://linkedin.com/in/johnsmith',
+          'Key Background': 'Security expert',
+          'Talking Points': 'Zero trust advocate',
+          'Date Found': '2026-01-30',
+        },
+      ],
+      docContent: '# Acme Corp - IT Leadership Research\n...',
+      analysis: JSON.parse(MOCK_CLAUDE_RESPONSE.content[0].text),
+    },
+    // Weekly Report mocks
+    'SEC EDGAR Check New Filings': MOCK_SEC_EDGAR,
+    'Claude Delta Analysis': MOCK_CLAUDE_DELTA_RESPONSE,
+    'Read Existing Leaders': MOCK_EXISTING_LEADERS,
+    'Format Weekly Delta': {
+      companyName: 'Acme Corp',
+      weeklyUpdateText: '### Week of 2026-01-30\n\n**Summary:** No significant changes.',
+      newLeaderRows: [],
+      masterSummaryLine: '**Acme Corp:** No significant changes this week.',
+      weekOf: '2026-01-30',
+      delta: JSON.parse(MOCK_CLAUDE_DELTA_RESPONSE.content[0].text),
+    },
+    'Parse New Filings': {
+      newFilings: [
+        { form: '10-K', date: '2025-06-15', company: 'Acme Corp', url: '/Archives/edgar/data/123/filing.htm', accession: '0001234-25-000001' },
+      ],
+      hasNewFilings: true,
+    },
+  };
+
+  // $('NodeName') returns an object with .item.json
+  function $(nodeName) {
+    const data = mockNodeData[nodeName];
+    if (data === undefined) {
+      return { item: { json: {} } };
+    }
+    // If data is an array, treat as multiple items (e.g. Read Existing Leaders)
+    if (Array.isArray(data)) {
+      return { item: { json: data[0] || {} } };
+    }
+    return { item: { json: data } };
+  }
+
+  // $input for nodes that use $input.all()
+  const $input = {
+    all() {
+      return [
+        { json: { companyName: 'Acme Corp', summaryLine: '**Acme Corp:** No significant changes this week.' } },
+        { json: { companyName: 'Widget Inc', summaryLine: '**Widget Inc:** New CTO appointed.' } },
+      ];
+    },
+  };
+
+  // $json is the current item's json
+  const $json = {
+    filingText: 'Technology investments include cloud migration and cybersecurity...',
+    filingUrl: 'https://www.sec.gov/Archives/edgar/data/123/filing.htm',
+    filings: [{ form: '10-K', date: '2025-06-15', company: 'Acme Corp', url: '' }],
+  };
+
+  return { $, $input, $json };
+}
+
+for (const [file, wf] of Object.entries(workflows)) {
+  if (!wf) continue;
+  const label = wf.name || file;
+
+  const codeNodes = wf.nodes.filter((n) => n.type === 'n8n-nodes-base.code');
+
+  for (const node of codeNodes) {
+    const jsCode = node.parameters?.jsCode;
+    if (!jsCode) {
+      fail(`[${label}] "${node.name}" has jsCode`);
+      continue;
+    }
+
+    const { $, $input, $json } = buildMockContext(label);
+
+    try {
+      // Wrap the code in a function. n8n code nodes implicitly return the last expression
+      // or use explicit `return`. We wrap in an IIFE.
+      const wrappedCode = `
+        const $ = arguments[0];
+        const $input = arguments[1];
+        const $json = arguments[2];
+        ${jsCode}
+      `;
+
+      const fn = new Function(wrappedCode);
+      const result = fn($, $input, $json);
+
+      // Verify it returns something (not undefined/null for most nodes)
+      if (result === undefined || result === null) {
+        // Some code nodes return arrays — check if the code uses `return [...`
+        // Actually n8n code nodes always return; if undefined, that's also OK in some cases
+        // But per the plan we want to verify it returns an object
+        fail(`[${label}] "${node.name}" returns a value`, 'got undefined/null');
+      } else {
+        pass(`[${label}] "${node.name}" executes without error and returns ${typeof result}`);
+      }
+    } catch (e) {
+      fail(`[${label}] "${node.name}" executes without error`, e.message);
+    }
+  }
+}
+
+// ─── 5. Claude Request Validation ───────────────────────────────────────────
+
+section('5. Claude Request Validation');
+
+for (const [file, wf] of Object.entries(workflows)) {
+  if (!wf) continue;
+  const label = wf.name || file;
+
+  // Find HTTP request nodes that POST to Claude
+  const claudeNodes = wf.nodes.filter(
+    (n) =>
+      n.type === 'n8n-nodes-base.httpRequest' &&
+      n.parameters?.url === 'https://api.anthropic.com/v1/messages' &&
+      n.parameters?.method === 'POST',
+  );
+
+  for (const node of claudeNodes) {
+    const jsonBodyRaw = node.parameters?.jsonBody;
+    if (!jsonBodyRaw) {
+      fail(`[${label}] "${node.name}" has jsonBody`);
+      continue;
+    }
+
+    // Strip the leading = that n8n uses for expression mode
+    let bodyStr = jsonBodyRaw;
+    if (bodyStr.startsWith('=')) bodyStr = bodyStr.slice(1);
+
+    // Replace n8n expressions with placeholder strings for JSON validation
+    // Expressions look like {{ ... }}
+    bodyStr = bodyStr.replace(/\{\{[^}]+\}\}/g, '"__EXPRESSION__"');
+
+    try {
+      const bodyObj = JSON.parse(bodyStr);
+
+      assert(
+        typeof bodyObj.model === 'string' && bodyObj.model.length > 0,
+        `[${label}] "${node.name}" has "model" field`,
+        `got: ${bodyObj.model}`,
+      );
+      assert(
+        typeof bodyObj.max_tokens === 'number' && bodyObj.max_tokens > 0,
+        `[${label}] "${node.name}" has valid "max_tokens"`,
+        `got: ${bodyObj.max_tokens}`,
+      );
+      assert(
+        typeof bodyObj.system === 'string' && bodyObj.system.length > 0,
+        `[${label}] "${node.name}" has "system" prompt`,
+      );
+      assert(
+        Array.isArray(bodyObj.messages) && bodyObj.messages.length > 0,
+        `[${label}] "${node.name}" has "messages" array`,
+      );
+
+      // Check that messages have role and content
+      for (let i = 0; i < bodyObj.messages.length; i++) {
+        const msg = bodyObj.messages[i];
+        assert(
+          msg.role && msg.content,
+          `[${label}] "${node.name}" message[${i}] has role and content`,
+        );
+      }
+
+      // Check that expression node references in the user message exist in workflow
+      const nodeNames = new Set(wf.nodes.map((n) => n.name));
+      const userContent = jsonBodyRaw; // Use original with expressions
+      const exprRefPattern = /\$\('([^']+)'\)/g;
+      const promptRefs = new Set();
+      let m;
+      while ((m = exprRefPattern.exec(userContent)) !== null) {
+        promptRefs.add(m[1]);
+      }
+      const missingPromptRefs = [];
+      for (const ref of promptRefs) {
+        if (!nodeNames.has(ref)) {
+          missingPromptRefs.push(ref);
+        }
+      }
+      assert(
+        missingPromptRefs.length === 0,
+        `[${label}] "${node.name}" prompt node references are valid`,
+        `missing: ${missingPromptRefs.join(', ')}`,
+      );
+
+      pass(`[${label}] "${node.name}" JSON body is structurally valid`);
+    } catch (e) {
+      fail(
+        `[${label}] "${node.name}" jsonBody parses as valid JSON (after expression substitution)`,
+        e.message,
+      );
+    }
+  }
+}
+
+// ─── Report ─────────────────────────────────────────────────────────────────
+
+section('RESULTS');
+console.log(`  Passed: ${passed}`);
+console.log(`  Failed: ${failed}`);
+
+if (failures.length > 0) {
+  console.log('\nFailures:');
+  for (const f of failures) {
+    console.log(`  - ${f}`);
+  }
+}
+
+console.log(`\n${failed === 0 ? 'ALL CHECKS PASSED' : 'SOME CHECKS FAILED'}`);
+process.exit(failed === 0 ? 0 : 1);

--- a/workflow-research-pipeline.json
+++ b/workflow-research-pipeline.json
@@ -81,18 +81,14 @@
     {
       "parameters": {
         "method": "GET",
-        "url": "https://nubela.co/proxycurl/api/linkedin/company/resolve",
+        "url": "https://api.apollo.io/api/v1/organizations/enrich",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "sendQuery": true,
         "queryParameters": {
           "parameters": [
             {
-              "name": "company_name",
-              "value": "={{ $json['Company Name'] }}"
-            },
-            {
-              "name": "company_domain",
+              "name": "domain",
               "value": "={{ $json['Website'] }}"
             }
           ]
@@ -101,15 +97,15 @@
           "timeout": 30000
         }
       },
-      "id": "proxycurl-resolve",
-      "name": "Proxycurl Resolve Company",
+      "id": "apollo-resolve",
+      "name": "Apollo Resolve Company",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [880, 400],
       "credentials": {
         "httpHeaderAuth": {
-          "id": "proxycurl-api",
-          "name": "Proxycurl API Key"
+          "id": "apollo-api",
+          "name": "Apollo API Key"
         }
       },
       "onError": "continueRegularOutput",
@@ -128,24 +124,92 @@
     },
     {
       "parameters": {
-        "method": "GET",
-        "url": "https://nubela.co/proxycurl/api/linkedin/company/employees/",
+        "method": "POST",
+        "url": "https://api.apollo.io/api/v1/mixed_people/api_search",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "sendQuery": true,
         "queryParameters": {
           "parameters": [
             {
-              "name": "linkedin_company_profile_url",
-              "value": "={{ $('Proxycurl Resolve Company').item.json.url || $('Loop Over Companies').item.json['LinkedIn URL'] }}"
+              "name": "q_organization_domains",
+              "value": "={{ $json['Website'] || $('Apollo Resolve Company').item.json.primary_domain || '' }}"
             },
             {
-              "name": "keyword_regex",
-              "value": "CIO|CTO|CISO|CDO|Chief Information Officer|Chief Technology Officer|Chief Information Security Officer|Chief Digital Officer|VP of IT|VP Engineering|VP Infrastructure|VP Security|VP Technology|VP Information Systems|Director of IT|Director of Engineering|Director of Infrastructure|Director of Security|Director of Technology"
+              "name": "person_titles[]",
+              "value": "CIO"
             },
             {
-              "name": "enrich_profiles",
-              "value": "enrich"
+              "name": "person_titles[]",
+              "value": "CTO"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "CISO"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "CDO"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Chief Information Officer"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Chief Technology Officer"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Chief Information Security Officer"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Chief Digital Officer"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "VP of IT"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "VP Engineering"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "VP Infrastructure"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "VP Security"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "VP Technology"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Director of IT"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Director of Engineering"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Director of Infrastructure"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Director of Security"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Director of Technology"
+            },
+            {
+              "name": "per_page",
+              "value": "25"
             }
           ]
         },
@@ -153,15 +217,15 @@
           "timeout": 60000
         }
       },
-      "id": "proxycurl-employees",
-      "name": "Proxycurl Search IT Leaders",
+      "id": "apollo-employees",
+      "name": "Apollo Search IT Leaders",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [1320, 400],
       "credentials": {
         "httpHeaderAuth": {
-          "id": "proxycurl-api",
-          "name": "Proxycurl API Key"
+          "id": "apollo-api",
+          "name": "Apollo API Key"
         }
       },
       "onError": "continueRegularOutput",
@@ -369,7 +433,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 4096,\n  \"system\": \"You are an expert business researcher specializing in IT leadership and corporate technology strategy. You analyze company data to produce structured research profiles for sales teams.\\n\\nAlways output valid JSON matching this schema:\\n{\\n  \\\"company\\\": { \\\"name\\\": string, \\\"ticker\\\": string, \\\"website\\\": string },\\n  \\\"it_leaders\\\": [\\n    {\\n      \\\"name\\\": string,\\n      \\\"title\\\": string,\\n      \\\"linkedin_url\\\": string,\\n      \\\"key_background\\\": string,\\n      \\\"talking_points\\\": [string]\\n    }\\n  ],\\n  \\\"strategic_initiatives\\\": [\\n    {\\n      \\\"initiative\\\": string,\\n      \\\"description\\\": string,\\n      \\\"filing_reference\\\": string\\n    }\\n  ],\\n  \\\"technology_themes\\\": [\\n    {\\n      \\\"theme\\\": string,\\n      \\\"priority\\\": \\\"high\\\" | \\\"medium\\\" | \\\"low\\\",\\n      \\\"evidence\\\": string\\n    }\\n  ],\\n  \\\"summary\\\": string\\n}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Research the following company and produce a structured analysis:\\n\\nCompany: {{ $('Loop Over Companies').item.json['Company Name'] }}\\nTicker: {{ $('Loop Over Companies').item.json['Ticker'] }}\\nWebsite: {{ $('Loop Over Companies').item.json['Website'] }}\\n\\n--- IT LEADERS FROM LINKEDIN (via Proxycurl) ---\\n{{ JSON.stringify($('Proxycurl Search IT Leaders').item.json.employees || $('Proxycurl Search IT Leaders').item.json || [], null, 2) }}\\n\\n--- SEC 10-K FILING EXCERPTS ---\\n{{ $json.filingText || 'No filing data available.' }}\\n\\n--- INSTRUCTIONS ---\\n1. Extract and profile each IT leader found. For each, provide their name, exact title, LinkedIn URL, a brief background summary, and 3-5 personalized talking points a salesperson could use.\\n2. From the 10-K filing, identify strategic IT initiatives, digital transformation efforts, technology investments, and cybersecurity priorities.\\n3. Synthesize overarching technology themes and rate their priority (high/medium/low) based on evidence.\\n4. Write a brief executive summary (2-3 sentences) of the company's IT landscape.\\n\\nOutput ONLY valid JSON matching the required schema.\"\n    }\n  ]\n}",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 4096,\n  \"system\": \"You are an expert business researcher specializing in IT leadership and corporate technology strategy. You analyze company data to produce structured research profiles for sales teams.\\n\\nAlways output valid JSON matching this schema:\\n{\\n  \\\"company\\\": { \\\"name\\\": string, \\\"ticker\\\": string, \\\"website\\\": string },\\n  \\\"it_leaders\\\": [\\n    {\\n      \\\"name\\\": string,\\n      \\\"title\\\": string,\\n      \\\"linkedin_url\\\": string,\\n      \\\"key_background\\\": string,\\n      \\\"talking_points\\\": [string]\\n    }\\n  ],\\n  \\\"strategic_initiatives\\\": [\\n    {\\n      \\\"initiative\\\": string,\\n      \\\"description\\\": string,\\n      \\\"filing_reference\\\": string\\n    }\\n  ],\\n  \\\"technology_themes\\\": [\\n    {\\n      \\\"theme\\\": string,\\n      \\\"priority\\\": \\\"high\\\" | \\\"medium\\\" | \\\"low\\\",\\n      \\\"evidence\\\": string\\n    }\\n  ],\\n  \\\"summary\\\": string\\n}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Research the following company and produce a structured analysis:\\n\\nCompany: {{ $('Loop Over Companies').item.json['Company Name'] }}\\nTicker: {{ $('Loop Over Companies').item.json['Ticker'] }}\\nWebsite: {{ $('Loop Over Companies').item.json['Website'] }}\\n\\n--- IT LEADERS FROM LINKEDIN (via Apollo) ---\\n{{ JSON.stringify($('Apollo Search IT Leaders').item.json.people || $('Apollo Search IT Leaders').item.json || [], null, 2) }}\\n\\n--- SEC 10-K FILING EXCERPTS ---\\n{{ $json.filingText || 'No filing data available.' }}\\n\\n--- INSTRUCTIONS ---\\n1. Extract and profile each IT leader found. For each, provide their name, exact title, LinkedIn URL, a brief background summary, and 3-5 personalized talking points a salesperson could use.\\n2. From the 10-K filing, identify strategic IT initiatives, digital transformation efforts, technology investments, and cybersecurity priorities.\\n3. Synthesize overarching technology themes and rate their priority (high/medium/low) based on evidence.\\n4. Write a brief executive summary (2-3 sentences) of the company's IT landscape.\\n\\nOutput ONLY valid JSON matching the required schema.\"\n    }\n  ]\n}",
         "options": {
           "timeout": 120000
         }
@@ -638,12 +702,12 @@
     "Loop Over Companies": {
       "main": [
         [
-          { "node": "Proxycurl Resolve Company", "type": "main", "index": 0 }
+          { "node": "Apollo Resolve Company", "type": "main", "index": 0 }
         ],
         []
       ]
     },
-    "Proxycurl Resolve Company": {
+    "Apollo Resolve Company": {
       "main": [
         [
           { "node": "Wait After Resolve", "type": "main", "index": 0 }
@@ -653,11 +717,11 @@
     "Wait After Resolve": {
       "main": [
         [
-          { "node": "Proxycurl Search IT Leaders", "type": "main", "index": 0 }
+          { "node": "Apollo Search IT Leaders", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Proxycurl Search IT Leaders": {
+    "Apollo Search IT Leaders": {
       "main": [
         [
           { "node": "Wait After Employees", "type": "main", "index": 0 }

--- a/workflow-weekly-report.json
+++ b/workflow-weekly-report.json
@@ -65,18 +65,14 @@
     {
       "parameters": {
         "method": "GET",
-        "url": "https://nubela.co/proxycurl/api/linkedin/company/resolve",
+        "url": "https://api.apollo.io/api/v1/organizations/enrich",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "sendQuery": true,
         "queryParameters": {
           "parameters": [
             {
-              "name": "company_name",
-              "value": "={{ $json['Company Name'] }}"
-            },
-            {
-              "name": "company_domain",
+              "name": "domain",
               "value": "={{ $json['Website'] }}"
             }
           ]
@@ -85,15 +81,15 @@
           "timeout": 30000
         }
       },
-      "id": "proxycurl-resolve",
-      "name": "Proxycurl Resolve Company",
+      "id": "apollo-resolve",
+      "name": "Apollo Resolve Company",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [900, 480],
       "credentials": {
         "httpHeaderAuth": {
-          "id": "proxycurl-api",
-          "name": "Proxycurl API Key"
+          "id": "apollo-api",
+          "name": "Apollo API Key"
         }
       },
       "onError": "continueRegularOutput",
@@ -112,24 +108,92 @@
     },
     {
       "parameters": {
-        "method": "GET",
-        "url": "https://nubela.co/proxycurl/api/linkedin/company/employees/",
+        "method": "POST",
+        "url": "https://api.apollo.io/api/v1/mixed_people/api_search",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "sendQuery": true,
         "queryParameters": {
           "parameters": [
             {
-              "name": "linkedin_company_profile_url",
-              "value": "={{ $('Proxycurl Resolve Company').item.json.url || $('Loop Over Companies').item.json['LinkedIn URL'] }}"
+              "name": "q_organization_domains",
+              "value": "={{ $json['Website'] || $('Apollo Resolve Company').item.json.primary_domain || '' }}"
             },
             {
-              "name": "keyword_regex",
-              "value": "CIO|CTO|CISO|CDO|Chief Information Officer|Chief Technology Officer|Chief Information Security Officer|Chief Digital Officer|VP of IT|VP Engineering|VP Infrastructure|VP Security|VP Technology|VP Information Systems|Director of IT|Director of Engineering|Director of Infrastructure|Director of Security|Director of Technology"
+              "name": "person_titles[]",
+              "value": "CIO"
             },
             {
-              "name": "enrich_profiles",
-              "value": "enrich"
+              "name": "person_titles[]",
+              "value": "CTO"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "CISO"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "CDO"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Chief Information Officer"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Chief Technology Officer"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Chief Information Security Officer"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Chief Digital Officer"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "VP of IT"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "VP Engineering"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "VP Infrastructure"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "VP Security"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "VP Technology"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Director of IT"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Director of Engineering"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Director of Infrastructure"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Director of Security"
+            },
+            {
+              "name": "person_titles[]",
+              "value": "Director of Technology"
+            },
+            {
+              "name": "per_page",
+              "value": "25"
             }
           ]
         },
@@ -137,15 +201,15 @@
           "timeout": 60000
         }
       },
-      "id": "proxycurl-employees",
-      "name": "Proxycurl Search IT Leaders",
+      "id": "apollo-employees",
+      "name": "Apollo Search IT Leaders",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [1340, 480],
       "credentials": {
         "httpHeaderAuth": {
-          "id": "proxycurl-api",
-          "name": "Proxycurl API Key"
+          "id": "apollo-api",
+          "name": "Apollo API Key"
         }
       },
       "onError": "continueRegularOutput",
@@ -297,7 +361,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 4096,\n  \"system\": \"You are an expert business researcher producing weekly incremental updates on IT leadership changes and corporate technology strategy. You compare new data against existing records to identify what is NEW and what has CHANGED.\\n\\nAlways output valid JSON matching this schema:\\n{\\n  \\\"company\\\": string,\\n  \\\"week_of\\\": string,\\n  \\\"new_leaders\\\": [{ \\\"name\\\": string, \\\"title\\\": string, \\\"linkedin_url\\\": string, \\\"background\\\": string, \\\"talking_points\\\": [string] }],\\n  \\\"changed_leaders\\\": [{ \\\"name\\\": string, \\\"previous_title\\\": string, \\\"new_title\\\": string, \\\"change_summary\\\": string }],\\n  \\\"departed_leaders\\\": [{ \\\"name\\\": string, \\\"previous_title\\\": string }],\\n  \\\"new_filings\\\": [{ \\\"form\\\": string, \\\"date\\\": string, \\\"key_findings\\\": string }],\\n  \\\"new_initiatives\\\": [{ \\\"initiative\\\": string, \\\"description\\\": string }],\\n  \\\"updated_themes\\\": [{ \\\"theme\\\": string, \\\"update\\\": string }],\\n  \\\"executive_summary\\\": string\\n}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Generate a weekly delta report for the following company:\\n\\nCompany: {{ $('Loop Over Companies').item.json['Company Name'] }}\\nWeek of: {{ new Date().toISOString().split('T')[0] }}\\n\\n--- CURRENT IT LEADERS FROM LINKEDIN (fresh Proxycurl data) ---\\n{{ JSON.stringify($('Proxycurl Search IT Leaders').item.json.employees || $('Proxycurl Search IT Leaders').item.json || [], null, 2) }}\\n\\n--- PREVIOUSLY KNOWN LEADERS (from our database) ---\\n{{ JSON.stringify($('Read Existing Leaders').item.json || [], null, 2) }}\\n\\n--- NEW SEC FILINGS SINCE LAST CHECK ---\\n{{ JSON.stringify($('Parse New Filings').item.json.newFilings || [], null, 2) }}\\n\\n--- INSTRUCTIONS ---\\n1. Compare the current LinkedIn leaders against previously known leaders. Identify:\\n   - NEW leaders (in current data but not in previous)\\n   - CHANGED leaders (same person but different title)\\n   - DEPARTED leaders (in previous data but not in current)\\n2. For new leaders, provide background and 3-5 talking points.\\n3. Summarize any new SEC filings and key technology-related findings.\\n4. Identify any new strategic initiatives or updated technology themes.\\n5. Write a brief executive summary (2-3 sentences) of what changed this week.\\n\\nIf nothing meaningful changed, still produce valid JSON with empty arrays and a summary noting no significant changes.\\n\\nOutput ONLY valid JSON matching the required schema.\"\n    }\n  ]\n}",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 4096,\n  \"system\": \"You are an expert business researcher producing weekly incremental updates on IT leadership changes and corporate technology strategy. You compare new data against existing records to identify what is NEW and what has CHANGED.\\n\\nAlways output valid JSON matching this schema:\\n{\\n  \\\"company\\\": string,\\n  \\\"week_of\\\": string,\\n  \\\"new_leaders\\\": [{ \\\"name\\\": string, \\\"title\\\": string, \\\"linkedin_url\\\": string, \\\"background\\\": string, \\\"talking_points\\\": [string] }],\\n  \\\"changed_leaders\\\": [{ \\\"name\\\": string, \\\"previous_title\\\": string, \\\"new_title\\\": string, \\\"change_summary\\\": string }],\\n  \\\"departed_leaders\\\": [{ \\\"name\\\": string, \\\"previous_title\\\": string }],\\n  \\\"new_filings\\\": [{ \\\"form\\\": string, \\\"date\\\": string, \\\"key_findings\\\": string }],\\n  \\\"new_initiatives\\\": [{ \\\"initiative\\\": string, \\\"description\\\": string }],\\n  \\\"updated_themes\\\": [{ \\\"theme\\\": string, \\\"update\\\": string }],\\n  \\\"executive_summary\\\": string\\n}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Generate a weekly delta report for the following company:\\n\\nCompany: {{ $('Loop Over Companies').item.json['Company Name'] }}\\nWeek of: {{ new Date().toISOString().split('T')[0] }}\\n\\n--- CURRENT IT LEADERS FROM LINKEDIN (via Apollo) ---\\n{{ JSON.stringify($('Apollo Search IT Leaders').item.json.people || $('Apollo Search IT Leaders').item.json || [], null, 2) }}\\n\\n--- PREVIOUSLY KNOWN LEADERS (from our database) ---\\n{{ JSON.stringify($('Read Existing Leaders').item.json || [], null, 2) }}\\n\\n--- NEW SEC FILINGS SINCE LAST CHECK ---\\n{{ JSON.stringify($('Parse New Filings').item.json.newFilings || [], null, 2) }}\\n\\n--- INSTRUCTIONS ---\\n1. Compare the current LinkedIn leaders against previously known leaders. Identify:\\n   - NEW leaders (in current data but not in previous)\\n   - CHANGED leaders (same person but different title)\\n   - DEPARTED leaders (in previous data but not in current)\\n2. For new leaders, provide background and 3-5 talking points.\\n3. Summarize any new SEC filings and key technology-related findings.\\n4. Identify any new strategic initiatives or updated technology themes.\\n5. Write a brief executive summary (2-3 sentences) of what changed this week.\\n\\nIf nothing meaningful changed, still produce valid JSON with empty arrays and a summary noting no significant changes.\\n\\nOutput ONLY valid JSON matching the required schema.\"\n    }\n  ]\n}",
         "options": {
           "timeout": 120000
         }
@@ -569,14 +633,14 @@
     "Loop Over Companies": {
       "main": [
         [
-          { "node": "Proxycurl Resolve Company", "type": "main", "index": 0 }
+          { "node": "Apollo Resolve Company", "type": "main", "index": 0 }
         ],
         [
           { "node": "Build Master Summary", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Proxycurl Resolve Company": {
+    "Apollo Resolve Company": {
       "main": [
         [
           { "node": "Wait 1", "type": "main", "index": 0 }
@@ -586,11 +650,11 @@
     "Wait 1": {
       "main": [
         [
-          { "node": "Proxycurl Search IT Leaders", "type": "main", "index": 0 }
+          { "node": "Apollo Search IT Leaders", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Proxycurl Search IT Leaders": {
+    "Apollo Search IT Leaders": {
       "main": [
         [
           { "node": "Wait 2", "type": "main", "index": 0 }


### PR DESCRIPTION
## Summary
- Replace Proxycurl API nodes with Apollo.io equivalents in both workflows after Proxycurl shutdown
- Company resolve: Apollo Organization Enrich (`GET /api/v1/organizations/enrich`) replaces Proxycurl's `/linkedin/company/resolve`
- People search: Apollo People Search (`POST /api/v1/mixed_people/api_search`) with `person_titles[]` filters replaces Proxycurl's `/linkedin/company/employees/` with `keyword_regex`
- Update all `$('...')` node references, connection graphs, and Claude prompt templates (`.employees` → `.people`)
- Add `test-dry-run.js` — offline validation script covering schema, connections, node references, code execution, and Claude prompt structure

## Test plan
- [ ] Install Node.js and run `node test-dry-run.js` — all checks should PASS
- [ ] Create Apollo.io account and obtain API key
- [ ] Configure `Apollo API Key` HTTP Header Auth credential in n8n (`x-api-key` header)
- [ ] Import updated workflows and verify no red credential warnings
- [ ] Manual test: run research pipeline with one company, confirm Apollo returns org + people data
- [ ] Manual test: run weekly report, confirm delta analysis works with Apollo response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)