### PR TITLE
Migrate LinkedIn data from Apollo.io to SearXNG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,9 @@
 - This repo contains two n8n workflow JSON files for company IT leadership research
 - **workflow-research-pipeline.json** — triggered on new Google Sheet row, researches a company end-to-end
 - **workflow-weekly-report.json** — runs weekly on cron, produces delta reports on leadership changes
-- External services: Anthropic Claude API, Google Sheets/Docs/Drive, SEC EDGAR, LinkedIn data (currently Apollo.io, may migrate to Google Custom Search)
+- External services: Anthropic Claude API, Google Sheets/Docs/Drive, SEC EDGAR, SearXNG (self-hosted, LinkedIn X-ray search)
+- SearXNG runs locally (default `http://localhost:8080`), configured via `SEARXNG_URL` env var
+- LinkedIn data is gathered via X-ray search (`site:linkedin.com/in` queries), parsed by a Code node
 - **test-dry-run.js** — offline validation script (schema, connections, references, code execution, Claude prompts)
 
 ## Tech Stack

--- a/test-dry-run.js
+++ b/test-dry-run.js
@@ -62,29 +62,49 @@ for (const file of WORKFLOW_FILES) {
 
 // ─── Mock data ──────────────────────────────────────────────────────────────
 
-const MOCK_APOLLO_RESOLVE = {
-  id: '5e66b6381e05b4008c8331b8',
-  name: 'Acme Corp',
-  website_url: 'http://www.acme.com',
-  linkedin_url: 'http://www.linkedin.com/company/acme',
-  primary_domain: 'acme.com',
-  industry: 'information technology & services',
-  estimated_num_employees: 500,
-};
-
-const MOCK_APOLLO_PEOPLE = {
-  total_entries: 1,
-  people: [
+const MOCK_SEARXNG_COMPANY = {
+  results: [
     {
-      id: '63519a6d6fa6ba00019200f8',
-      first_name: 'Jane',
-      last_name: 'Doe',
-      title: 'CTO',
-      name: 'Jane Doe',
-      linkedin_url: 'https://linkedin.com/in/janedoe',
-      organization: { name: 'Acme Corp' },
+      title: 'Acme Corp | LinkedIn',
+      url: 'https://www.linkedin.com/company/acme',
+      content: 'Acme Corp is a technology company specializing in cloud solutions...',
     },
   ],
+};
+
+const MOCK_SEARXNG_LEADERS = {
+  results: [
+    {
+      title: 'Jane Doe - CTO - Acme Corp | LinkedIn',
+      url: 'https://www.linkedin.com/in/janedoe',
+      content: 'Chief Technology Officer at Acme Corp. Former VP Engineering at BigCo.',
+    },
+    {
+      title: 'John Smith - CISO - Acme Corp | LinkedIn',
+      url: 'https://www.linkedin.com/in/johnsmith',
+      content: 'Chief Information Security Officer at Acme Corp. Cybersecurity expert.',
+    },
+  ],
+};
+
+const MOCK_PARSED_LEADERS = {
+  people: [
+    {
+      name: 'Jane Doe',
+      title: 'CTO',
+      linkedin_url: 'https://www.linkedin.com/in/janedoe',
+      source: 'searxng',
+      snippet: 'Chief Technology Officer at Acme Corp. Former VP Engineering at BigCo.',
+    },
+    {
+      name: 'John Smith',
+      title: 'CISO',
+      linkedin_url: 'https://www.linkedin.com/in/johnsmith',
+      source: 'searxng',
+      snippet: 'Chief Information Security Officer at Acme Corp. Cybersecurity expert.',
+    },
+  ],
+  totalFound: 2,
 };
 
 const MOCK_SEC_EDGAR = {
@@ -397,8 +417,9 @@ function buildMockContext(workflowName) {
     },
     'Claude Analysis': MOCK_CLAUDE_RESPONSE,
     'Loop Over Companies': MOCK_COMPANY_ROW,
-    'Apollo Resolve Company': MOCK_APOLLO_RESOLVE,
-    'Apollo Search IT Leaders': MOCK_APOLLO_PEOPLE,
+    'SearXNG Company Search': MOCK_SEARXNG_COMPANY,
+    'SearXNG Search IT Leaders': MOCK_SEARXNG_LEADERS,
+    'Parse LinkedIn Results': MOCK_PARSED_LEADERS,
     'Format Results': {
       companyName: 'Acme Corp',
       leaderRows: [

--- a/workflow-research-pipeline.json
+++ b/workflow-research-pipeline.json
@@ -81,15 +81,21 @@
     {
       "parameters": {
         "method": "GET",
-        "url": "https://api.apollo.io/api/v1/organizations/enrich",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "url": "={{ $env.SEARXNG_URL || 'http://localhost:8080' }}/search",
         "sendQuery": true,
         "queryParameters": {
           "parameters": [
             {
-              "name": "domain",
-              "value": "={{ $json['Website'] }}"
+              "name": "q",
+              "value": "=site:linkedin.com/company {{ $json['Company Name'] }}"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "engines",
+              "value": "google,bing,duckduckgo"
             }
           ]
         },
@@ -97,17 +103,11 @@
           "timeout": 30000
         }
       },
-      "id": "apollo-resolve",
-      "name": "Apollo Resolve Company",
+      "id": "searxng-company",
+      "name": "SearXNG Company Search",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [880, 400],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "apollo-api",
-          "name": "Apollo API Key"
-        }
-      },
       "onError": "continueRegularOutput",
       "continueOnFail": true
     },
@@ -124,92 +124,22 @@
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "https://api.apollo.io/api/v1/mixed_people/api_search",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "method": "GET",
+        "url": "={{ $env.SEARXNG_URL || 'http://localhost:8080' }}/search",
         "sendQuery": true,
         "queryParameters": {
           "parameters": [
             {
-              "name": "q_organization_domains",
-              "value": "={{ $json['Website'] || $('Apollo Resolve Company').item.json.primary_domain || '' }}"
+              "name": "q",
+              "value": "=site:linkedin.com/in (CTO OR CIO OR CISO OR CDO OR \"Chief Information Officer\" OR \"Chief Technology Officer\" OR \"Chief Information Security Officer\" OR \"Chief Digital Officer\" OR \"VP of IT\" OR \"VP Engineering\" OR \"VP Technology\" OR \"Director of IT\" OR \"Director of Engineering\" OR \"Director of Technology\") {{ $('Loop Over Companies').item.json['Company Name'] }}"
             },
             {
-              "name": "person_titles[]",
-              "value": "CIO"
+              "name": "format",
+              "value": "json"
             },
             {
-              "name": "person_titles[]",
-              "value": "CTO"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "CISO"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "CDO"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Chief Information Officer"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Chief Technology Officer"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Chief Information Security Officer"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Chief Digital Officer"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "VP of IT"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "VP Engineering"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "VP Infrastructure"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "VP Security"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "VP Technology"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Director of IT"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Director of Engineering"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Director of Infrastructure"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Director of Security"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Director of Technology"
-            },
-            {
-              "name": "per_page",
-              "value": "25"
+              "name": "engines",
+              "value": "google,bing,duckduckgo"
             }
           ]
         },
@@ -217,29 +147,22 @@
           "timeout": 60000
         }
       },
-      "id": "apollo-employees",
-      "name": "Apollo Search IT Leaders",
+      "id": "searxng-leaders",
+      "name": "SearXNG Search IT Leaders",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [1320, 400],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "apollo-api",
-          "name": "Apollo API Key"
-        }
-      },
       "onError": "continueRegularOutput",
       "continueOnFail": true
     },
     {
       "parameters": {
-        "amount": 2,
-        "unit": "seconds"
+        "jsCode": "// Parse SearXNG search results into structured people data\nconst results = $('SearXNG Search IT Leaders').item.json.results || [];\nconst companyName = $('Loop Over Companies').item.json['Company Name'];\n\nconst titlePatterns = [\n  'CTO', 'CIO', 'CISO', 'CDO',\n  'Chief Information Officer', 'Chief Technology Officer',\n  'Chief Information Security Officer', 'Chief Digital Officer',\n  'VP of IT', 'VP Engineering', 'VP Infrastructure', 'VP Security', 'VP Technology',\n  'VP Information Systems',\n  'Director of IT', 'Director of Engineering', 'Director of Infrastructure',\n  'Director of Security', 'Director of Technology'\n];\n\nconst people = [];\nconst seenUrls = new Set();\n\nfor (const r of results) {\n  const url = r.url || '';\n  // Only process linkedin.com/in/ profile URLs\n  if (!url.includes('linkedin.com/in/')) continue;\n  if (seenUrls.has(url)) continue;\n  seenUrls.add(url);\n\n  const title = r.title || '';\n  const snippet = r.content || '';\n  const combined = `${title} ${snippet}`;\n\n  // Extract name from LinkedIn title format: \"Name - Title - Company | LinkedIn\"\n  const nameParts = title.split(/\\s*[-–—|]\\s*/);\n  const name = nameParts[0]?.trim() || '';\n\n  // Find matching IT title\n  let matchedTitle = '';\n  for (const tp of titlePatterns) {\n    if (combined.toLowerCase().includes(tp.toLowerCase())) {\n      matchedTitle = tp;\n      break;\n    }\n  }\n\n  if (name && name !== 'LinkedIn') {\n    people.push({\n      name,\n      title: matchedTitle || nameParts[1]?.trim() || 'IT Leader',\n      linkedin_url: url.split('?')[0],\n      source: 'searxng',\n      snippet: snippet.substring(0, 200)\n    });\n  }\n}\n\nreturn { people, totalFound: people.length };"
       },
-      "id": "wait-after-employees",
-      "name": "Wait After Employees",
-      "type": "n8n-nodes-base.wait",
-      "typeVersion": 1.1,
+      "id": "parse-leader-results",
+      "name": "Parse LinkedIn Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
       "position": [1540, 400]
     },
     {
@@ -433,7 +356,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 4096,\n  \"system\": \"You are an expert business researcher specializing in IT leadership and corporate technology strategy. You analyze company data to produce structured research profiles for sales teams.\\n\\nAlways output valid JSON matching this schema:\\n{\\n  \\\"company\\\": { \\\"name\\\": string, \\\"ticker\\\": string, \\\"website\\\": string },\\n  \\\"it_leaders\\\": [\\n    {\\n      \\\"name\\\": string,\\n      \\\"title\\\": string,\\n      \\\"linkedin_url\\\": string,\\n      \\\"key_background\\\": string,\\n      \\\"talking_points\\\": [string]\\n    }\\n  ],\\n  \\\"strategic_initiatives\\\": [\\n    {\\n      \\\"initiative\\\": string,\\n      \\\"description\\\": string,\\n      \\\"filing_reference\\\": string\\n    }\\n  ],\\n  \\\"technology_themes\\\": [\\n    {\\n      \\\"theme\\\": string,\\n      \\\"priority\\\": \\\"high\\\" | \\\"medium\\\" | \\\"low\\\",\\n      \\\"evidence\\\": string\\n    }\\n  ],\\n  \\\"summary\\\": string\\n}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Research the following company and produce a structured analysis:\\n\\nCompany: {{ $('Loop Over Companies').item.json['Company Name'] }}\\nTicker: {{ $('Loop Over Companies').item.json['Ticker'] }}\\nWebsite: {{ $('Loop Over Companies').item.json['Website'] }}\\n\\n--- IT LEADERS FROM LINKEDIN (via Apollo) ---\\n{{ JSON.stringify($('Apollo Search IT Leaders').item.json.people || $('Apollo Search IT Leaders').item.json || [], null, 2) }}\\n\\n--- SEC 10-K FILING EXCERPTS ---\\n{{ $json.filingText || 'No filing data available.' }}\\n\\n--- INSTRUCTIONS ---\\n1. Extract and profile each IT leader found. For each, provide their name, exact title, LinkedIn URL, a brief background summary, and 3-5 personalized talking points a salesperson could use.\\n2. From the 10-K filing, identify strategic IT initiatives, digital transformation efforts, technology investments, and cybersecurity priorities.\\n3. Synthesize overarching technology themes and rate their priority (high/medium/low) based on evidence.\\n4. Write a brief executive summary (2-3 sentences) of the company's IT landscape.\\n\\nOutput ONLY valid JSON matching the required schema.\"\n    }\n  ]\n}",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 4096,\n  \"system\": \"You are an expert business researcher specializing in IT leadership and corporate technology strategy. You analyze company data to produce structured research profiles for sales teams.\\n\\nAlways output valid JSON matching this schema:\\n{\\n  \\\"company\\\": { \\\"name\\\": string, \\\"ticker\\\": string, \\\"website\\\": string },\\n  \\\"it_leaders\\\": [\\n    {\\n      \\\"name\\\": string,\\n      \\\"title\\\": string,\\n      \\\"linkedin_url\\\": string,\\n      \\\"key_background\\\": string,\\n      \\\"talking_points\\\": [string]\\n    }\\n  ],\\n  \\\"strategic_initiatives\\\": [\\n    {\\n      \\\"initiative\\\": string,\\n      \\\"description\\\": string,\\n      \\\"filing_reference\\\": string\\n    }\\n  ],\\n  \\\"technology_themes\\\": [\\n    {\\n      \\\"theme\\\": string,\\n      \\\"priority\\\": \\\"high\\\" | \\\"medium\\\" | \\\"low\\\",\\n      \\\"evidence\\\": string\\n    }\\n  ],\\n  \\\"summary\\\": string\\n}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Research the following company and produce a structured analysis:\\n\\nCompany: {{ $('Loop Over Companies').item.json['Company Name'] }}\\nTicker: {{ $('Loop Over Companies').item.json['Ticker'] }}\\nWebsite: {{ $('Loop Over Companies').item.json['Website'] }}\\n\\n--- IT LEADERS FROM LINKEDIN (via SearXNG) ---\\n{{ JSON.stringify($('Parse LinkedIn Results').item.json.people || [], null, 2) }}\\n\\n--- SEC 10-K FILING EXCERPTS ---\\n{{ $json.filingText || 'No filing data available.' }}\\n\\n--- INSTRUCTIONS ---\\n1. Extract and profile each IT leader found. For each, provide their name, exact title, LinkedIn URL, a brief background summary, and 3-5 personalized talking points a salesperson could use.\\n2. From the 10-K filing, identify strategic IT initiatives, digital transformation efforts, technology investments, and cybersecurity priorities.\\n3. Synthesize overarching technology themes and rate their priority (high/medium/low) based on evidence.\\n4. Write a brief executive summary (2-3 sentences) of the company's IT landscape.\\n\\nOutput ONLY valid JSON matching the required schema.\"\n    }\n  ]\n}",
         "options": {
           "timeout": 120000
         }
@@ -702,12 +625,12 @@
     "Loop Over Companies": {
       "main": [
         [
-          { "node": "Apollo Resolve Company", "type": "main", "index": 0 }
+          { "node": "SearXNG Company Search", "type": "main", "index": 0 }
         ],
         []
       ]
     },
-    "Apollo Resolve Company": {
+    "SearXNG Company Search": {
       "main": [
         [
           { "node": "Wait After Resolve", "type": "main", "index": 0 }
@@ -717,18 +640,18 @@
     "Wait After Resolve": {
       "main": [
         [
-          { "node": "Apollo Search IT Leaders", "type": "main", "index": 0 }
+          { "node": "SearXNG Search IT Leaders", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Apollo Search IT Leaders": {
+    "SearXNG Search IT Leaders": {
       "main": [
         [
-          { "node": "Wait After Employees", "type": "main", "index": 0 }
+          { "node": "Parse LinkedIn Results", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Wait After Employees": {
+    "Parse LinkedIn Results": {
       "main": [
         [
           { "node": "SEC EDGAR Search 10-K", "type": "main", "index": 0 }

--- a/workflow-weekly-report.json
+++ b/workflow-weekly-report.json
@@ -65,15 +65,21 @@
     {
       "parameters": {
         "method": "GET",
-        "url": "https://api.apollo.io/api/v1/organizations/enrich",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "url": "={{ $env.SEARXNG_URL || 'http://localhost:8080' }}/search",
         "sendQuery": true,
         "queryParameters": {
           "parameters": [
             {
-              "name": "domain",
-              "value": "={{ $json['Website'] }}"
+              "name": "q",
+              "value": "=site:linkedin.com/company {{ $json['Company Name'] }}"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "engines",
+              "value": "google,bing,duckduckgo"
             }
           ]
         },
@@ -81,17 +87,11 @@
           "timeout": 30000
         }
       },
-      "id": "apollo-resolve",
-      "name": "Apollo Resolve Company",
+      "id": "searxng-company",
+      "name": "SearXNG Company Search",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [900, 480],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "apollo-api",
-          "name": "Apollo API Key"
-        }
-      },
       "onError": "continueRegularOutput",
       "continueOnFail": true
     },
@@ -108,92 +108,22 @@
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "https://api.apollo.io/api/v1/mixed_people/api_search",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "method": "GET",
+        "url": "={{ $env.SEARXNG_URL || 'http://localhost:8080' }}/search",
         "sendQuery": true,
         "queryParameters": {
           "parameters": [
             {
-              "name": "q_organization_domains",
-              "value": "={{ $json['Website'] || $('Apollo Resolve Company').item.json.primary_domain || '' }}"
+              "name": "q",
+              "value": "=site:linkedin.com/in (CTO OR CIO OR CISO OR CDO OR \"Chief Information Officer\" OR \"Chief Technology Officer\" OR \"Chief Information Security Officer\" OR \"Chief Digital Officer\" OR \"VP of IT\" OR \"VP Engineering\" OR \"VP Technology\" OR \"Director of IT\" OR \"Director of Engineering\" OR \"Director of Technology\") {{ $('Loop Over Companies').item.json['Company Name'] }}"
             },
             {
-              "name": "person_titles[]",
-              "value": "CIO"
+              "name": "format",
+              "value": "json"
             },
             {
-              "name": "person_titles[]",
-              "value": "CTO"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "CISO"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "CDO"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Chief Information Officer"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Chief Technology Officer"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Chief Information Security Officer"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Chief Digital Officer"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "VP of IT"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "VP Engineering"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "VP Infrastructure"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "VP Security"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "VP Technology"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Director of IT"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Director of Engineering"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Director of Infrastructure"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Director of Security"
-            },
-            {
-              "name": "person_titles[]",
-              "value": "Director of Technology"
-            },
-            {
-              "name": "per_page",
-              "value": "25"
+              "name": "engines",
+              "value": "google,bing,duckduckgo"
             }
           ]
         },
@@ -201,29 +131,22 @@
           "timeout": 60000
         }
       },
-      "id": "apollo-employees",
-      "name": "Apollo Search IT Leaders",
+      "id": "searxng-leaders",
+      "name": "SearXNG Search IT Leaders",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [1340, 480],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "apollo-api",
-          "name": "Apollo API Key"
-        }
-      },
       "onError": "continueRegularOutput",
       "continueOnFail": true
     },
     {
       "parameters": {
-        "amount": 2,
-        "unit": "seconds"
+        "jsCode": "// Parse SearXNG search results into structured people data\nconst results = $('SearXNG Search IT Leaders').item.json.results || [];\nconst companyName = $('Loop Over Companies').item.json['Company Name'];\n\nconst titlePatterns = [\n  'CTO', 'CIO', 'CISO', 'CDO',\n  'Chief Information Officer', 'Chief Technology Officer',\n  'Chief Information Security Officer', 'Chief Digital Officer',\n  'VP of IT', 'VP Engineering', 'VP Infrastructure', 'VP Security', 'VP Technology',\n  'VP Information Systems',\n  'Director of IT', 'Director of Engineering', 'Director of Infrastructure',\n  'Director of Security', 'Director of Technology'\n];\n\nconst people = [];\nconst seenUrls = new Set();\n\nfor (const r of results) {\n  const url = r.url || '';\n  if (!url.includes('linkedin.com/in/')) continue;\n  if (seenUrls.has(url)) continue;\n  seenUrls.add(url);\n\n  const title = r.title || '';\n  const snippet = r.content || '';\n  const combined = `${title} ${snippet}`;\n\n  const nameParts = title.split(/\\s*[-\\u2013\\u2014|]\\s*/);\n  const name = nameParts[0]?.trim() || '';\n\n  let matchedTitle = '';\n  for (const tp of titlePatterns) {\n    if (combined.toLowerCase().includes(tp.toLowerCase())) {\n      matchedTitle = tp;\n      break;\n    }\n  }\n\n  if (name && name !== 'LinkedIn') {\n    people.push({\n      name,\n      title: matchedTitle || nameParts[1]?.trim() || 'IT Leader',\n      linkedin_url: url.split('?')[0],\n      source: 'searxng',\n      snippet: snippet.substring(0, 200)\n    });\n  }\n}\n\nreturn { people, totalFound: people.length };"
       },
-      "id": "wait-2",
-      "name": "Wait 2",
-      "type": "n8n-nodes-base.wait",
-      "typeVersion": 1.1,
+      "id": "parse-leader-results",
+      "name": "Parse LinkedIn Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
       "position": [1560, 480]
     },
     {
@@ -361,7 +284,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 4096,\n  \"system\": \"You are an expert business researcher producing weekly incremental updates on IT leadership changes and corporate technology strategy. You compare new data against existing records to identify what is NEW and what has CHANGED.\\n\\nAlways output valid JSON matching this schema:\\n{\\n  \\\"company\\\": string,\\n  \\\"week_of\\\": string,\\n  \\\"new_leaders\\\": [{ \\\"name\\\": string, \\\"title\\\": string, \\\"linkedin_url\\\": string, \\\"background\\\": string, \\\"talking_points\\\": [string] }],\\n  \\\"changed_leaders\\\": [{ \\\"name\\\": string, \\\"previous_title\\\": string, \\\"new_title\\\": string, \\\"change_summary\\\": string }],\\n  \\\"departed_leaders\\\": [{ \\\"name\\\": string, \\\"previous_title\\\": string }],\\n  \\\"new_filings\\\": [{ \\\"form\\\": string, \\\"date\\\": string, \\\"key_findings\\\": string }],\\n  \\\"new_initiatives\\\": [{ \\\"initiative\\\": string, \\\"description\\\": string }],\\n  \\\"updated_themes\\\": [{ \\\"theme\\\": string, \\\"update\\\": string }],\\n  \\\"executive_summary\\\": string\\n}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Generate a weekly delta report for the following company:\\n\\nCompany: {{ $('Loop Over Companies').item.json['Company Name'] }}\\nWeek of: {{ new Date().toISOString().split('T')[0] }}\\n\\n--- CURRENT IT LEADERS FROM LINKEDIN (via Apollo) ---\\n{{ JSON.stringify($('Apollo Search IT Leaders').item.json.people || $('Apollo Search IT Leaders').item.json || [], null, 2) }}\\n\\n--- PREVIOUSLY KNOWN LEADERS (from our database) ---\\n{{ JSON.stringify($('Read Existing Leaders').item.json || [], null, 2) }}\\n\\n--- NEW SEC FILINGS SINCE LAST CHECK ---\\n{{ JSON.stringify($('Parse New Filings').item.json.newFilings || [], null, 2) }}\\n\\n--- INSTRUCTIONS ---\\n1. Compare the current LinkedIn leaders against previously known leaders. Identify:\\n   - NEW leaders (in current data but not in previous)\\n   - CHANGED leaders (same person but different title)\\n   - DEPARTED leaders (in previous data but not in current)\\n2. For new leaders, provide background and 3-5 talking points.\\n3. Summarize any new SEC filings and key technology-related findings.\\n4. Identify any new strategic initiatives or updated technology themes.\\n5. Write a brief executive summary (2-3 sentences) of what changed this week.\\n\\nIf nothing meaningful changed, still produce valid JSON with empty arrays and a summary noting no significant changes.\\n\\nOutput ONLY valid JSON matching the required schema.\"\n    }\n  ]\n}",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 4096,\n  \"system\": \"You are an expert business researcher producing weekly incremental updates on IT leadership changes and corporate technology strategy. You compare new data against existing records to identify what is NEW and what has CHANGED.\\n\\nAlways output valid JSON matching this schema:\\n{\\n  \\\"company\\\": string,\\n  \\\"week_of\\\": string,\\n  \\\"new_leaders\\\": [{ \\\"name\\\": string, \\\"title\\\": string, \\\"linkedin_url\\\": string, \\\"background\\\": string, \\\"talking_points\\\": [string] }],\\n  \\\"changed_leaders\\\": [{ \\\"name\\\": string, \\\"previous_title\\\": string, \\\"new_title\\\": string, \\\"change_summary\\\": string }],\\n  \\\"departed_leaders\\\": [{ \\\"name\\\": string, \\\"previous_title\\\": string }],\\n  \\\"new_filings\\\": [{ \\\"form\\\": string, \\\"date\\\": string, \\\"key_findings\\\": string }],\\n  \\\"new_initiatives\\\": [{ \\\"initiative\\\": string, \\\"description\\\": string }],\\n  \\\"updated_themes\\\": [{ \\\"theme\\\": string, \\\"update\\\": string }],\\n  \\\"executive_summary\\\": string\\n}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Generate a weekly delta report for the following company:\\n\\nCompany: {{ $('Loop Over Companies').item.json['Company Name'] }}\\nWeek of: {{ new Date().toISOString().split('T')[0] }}\\n\\n--- CURRENT IT LEADERS FROM LINKEDIN (via SearXNG) ---\\n{{ JSON.stringify($('Parse LinkedIn Results').item.json.people || [], null, 2) }}\\n\\n--- PREVIOUSLY KNOWN LEADERS (from our database) ---\\n{{ JSON.stringify($('Read Existing Leaders').item.json || [], null, 2) }}\\n\\n--- NEW SEC FILINGS SINCE LAST CHECK ---\\n{{ JSON.stringify($('Parse New Filings').item.json.newFilings || [], null, 2) }}\\n\\n--- INSTRUCTIONS ---\\n1. Compare the current LinkedIn leaders against previously known leaders. Identify:\\n   - NEW leaders (in current data but not in previous)\\n   - CHANGED leaders (same person but different title)\\n   - DEPARTED leaders (in previous data but not in current)\\n2. For new leaders, provide background and 3-5 talking points.\\n3. Summarize any new SEC filings and key technology-related findings.\\n4. Identify any new strategic initiatives or updated technology themes.\\n5. Write a brief executive summary (2-3 sentences) of what changed this week.\\n\\nIf nothing meaningful changed, still produce valid JSON with empty arrays and a summary noting no significant changes.\\n\\nOutput ONLY valid JSON matching the required schema.\"\n    }\n  ]\n}",
         "options": {
           "timeout": 120000
         }
@@ -633,14 +556,14 @@
     "Loop Over Companies": {
       "main": [
         [
-          { "node": "Apollo Resolve Company", "type": "main", "index": 0 }
+          { "node": "SearXNG Company Search", "type": "main", "index": 0 }
         ],
         [
           { "node": "Build Master Summary", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Apollo Resolve Company": {
+    "SearXNG Company Search": {
       "main": [
         [
           { "node": "Wait 1", "type": "main", "index": 0 }
@@ -650,18 +573,18 @@
     "Wait 1": {
       "main": [
         [
-          { "node": "Apollo Search IT Leaders", "type": "main", "index": 0 }
+          { "node": "SearXNG Search IT Leaders", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Apollo Search IT Leaders": {
+    "SearXNG Search IT Leaders": {
       "main": [
         [
-          { "node": "Wait 2", "type": "main", "index": 0 }
+          { "node": "Parse LinkedIn Results", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Wait 2": {
+    "Parse LinkedIn Results": {
       "main": [
         [
           { "node": "SEC EDGAR Check New Filings", "type": "main", "index": 0 },


### PR DESCRIPTION
## Summary
- Replace Apollo.io paid API with self-hosted SearXNG (free, no API keys)
- LinkedIn data gathered via X-ray search (`site:linkedin.com/in` + title keywords)
- New `Parse LinkedIn Results` code node normalizes SearXNG results into structured people data
- Removes Apollo credentials/auth — SearXNG runs locally at `http://localhost:8080` (configurable via `SEARXNG_URL` env var)
- Net reduction: 112 additions, 243 deletions (simpler config, no auth boilerplate)

## What changed
| Before (Apollo) | After (SearXNG) |
|---|---|
| `Apollo Resolve Company` — paid org enrichment API | `SearXNG Company Search` — free X-ray search |
| `Apollo Search IT Leaders` — paid people search with `person_titles[]` | `SearXNG Search IT Leaders` + `Parse LinkedIn Results` — free search + code parser |
| HTTP Header Auth credential required | No auth needed (local instance) |
| `Wait After Employees` node for rate limiting | Removed (local, no rate limits) |

## Test plan
- [ ] Run `node test-dry-run.js` — all checks should PASS
- [ ] Start SearXNG locally: `docker run -d -p 8080:8080 -e SEARXNG_SEARCH_FORMATS=json searxng/searxng`
- [ ] Test search manually: `curl 'http://localhost:8080/search?q=site:linkedin.com/in+CTO+Microsoft&format=json'`
- [ ] Import workflows into n8n and verify all nodes resolve
- [ ] Run research pipeline with one test company

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)