### PR TITLE
Add setup script for Google Sheet, Drive folder, and summary doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Environment and credentials
+.env
+credentials.json
+token.json
+
+# Node
+node_modules/
+
+# OS
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,16 @@
 - Google Cloud (OAuth2 for Sheets/Docs/Drive APIs)
 - Anthropic Claude API (claude-sonnet-4-20250514)
 
+## Setup: Google Sheet & Drive Folder
+1. Go to https://script.google.com → **New Project**
+2. Paste the contents of `scripts/setup-google-sheet.gs` into the editor
+3. Run the `setup()` function and authorize when prompted
+4. Copy the three environment variable IDs from the alert dialog:
+   - `GOOGLE_SHEET_ID`
+   - `GOOGLE_DRIVE_FOLDER_ID`
+   - `MASTER_SUMMARY_DOC_ID`
+5. Add these to your n8n instance environment variables
+
 ## Conventions
 - Commit messages should be descriptive with a summary line and body
 - PRs should include a test plan

--- a/scripts/setup-google-sheet.gs
+++ b/scripts/setup-google-sheet.gs
@@ -1,0 +1,110 @@
+/**
+ * Setup script for Company Research Tracker.
+ *
+ * Usage:
+ *   1. Go to https://script.google.com → New Project
+ *   2. Paste this entire file into the editor
+ *   3. Run the setup() function
+ *   4. Authorize when prompted (Sheets, Docs, Drive scopes)
+ *   5. Copy the environment variable IDs from the alert dialog / execution log
+ */
+
+function setup() {
+  var sheet = createTrackingSheet();
+  var folder = createDriveFolder();
+  var doc = createSummaryDoc(folder);
+
+  var output = [
+    'Add these to your n8n environment variables:',
+    '',
+    'GOOGLE_SHEET_ID=' + sheet.getId(),
+    'GOOGLE_DRIVE_FOLDER_ID=' + folder.getId(),
+    'MASTER_SUMMARY_DOC_ID=' + doc.getId()
+  ].join('\n');
+
+  Logger.log(output);
+  SpreadsheetApp.getUi().alert(output);
+}
+
+/**
+ * Creates the "Company Research Tracker" spreadsheet with Companies and Leaders tabs.
+ */
+function createTrackingSheet() {
+  var ss = SpreadsheetApp.create('Company Research Tracker');
+
+  // -- Companies tab (rename the default Sheet1) --
+  var companiesTab = ss.getSheets()[0];
+  companiesTab.setName('Companies');
+
+  var companiesHeaders = [
+    'Company Name',
+    'Ticker',
+    'Website',
+    'LinkedIn URL',
+    'Status',
+    'Last Researched'
+  ];
+  var headerRange = companiesTab.getRange(1, 1, 1, companiesHeaders.length);
+  headerRange.setValues([companiesHeaders]);
+  headerRange.setFontWeight('bold');
+  companiesTab.setFrozenRows(1);
+
+  // Auto-resize columns to fit header text
+  for (var i = 1; i <= companiesHeaders.length; i++) {
+    companiesTab.autoResizeColumn(i);
+  }
+
+  // -- Leaders tab --
+  var leadersTab = ss.insertSheet('Leaders');
+
+  var leadersHeaders = [
+    'Company',
+    'Name',
+    'Title',
+    'LinkedIn URL',
+    'Key Background',
+    'Talking Points',
+    'Date Found'
+  ];
+  var leaderHeaderRange = leadersTab.getRange(1, 1, 1, leadersHeaders.length);
+  leaderHeaderRange.setValues([leadersHeaders]);
+  leaderHeaderRange.setFontWeight('bold');
+  leadersTab.setFrozenRows(1);
+
+  for (var i = 1; i <= leadersHeaders.length; i++) {
+    leadersTab.autoResizeColumn(i);
+  }
+
+  Logger.log('Created spreadsheet: ' + ss.getUrl());
+  return ss;
+}
+
+/**
+ * Creates the "Company Research Docs" folder in Google Drive.
+ */
+function createDriveFolder() {
+  var folder = DriveApp.createFolder('Company Research Docs');
+  Logger.log('Created folder: ' + folder.getUrl());
+  return folder;
+}
+
+/**
+ * Creates the "Weekly Research Summary" doc inside the given folder.
+ */
+function createSummaryDoc(folder) {
+  var doc = DocumentApp.create('Weekly Research Summary');
+  var docFile = DriveApp.getFileById(doc.getId());
+  folder.addFile(docFile);
+  // Remove from root so it only lives in the research folder
+  DriveApp.getRootFolder().removeFile(docFile);
+
+  doc.getBody().appendParagraph('Weekly Research Summary')
+    .setHeading(DocumentApp.ParagraphHeading.HEADING1);
+  doc.getBody().appendParagraph(
+    'This document is automatically updated by the weekly research workflow.'
+  );
+  doc.saveAndClose();
+
+  Logger.log('Created summary doc: ' + doc.getUrl());
+  return doc;
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/setup-google-sheet.gs` — a Google Apps Script that auto-creates the Company Research Tracker spreadsheet (Companies + Leaders tabs with exact column headers), a Drive folder, and a master summary doc
- Adds `.gitignore` for credentials, `.env`, and `node_modules`
- Documents the setup process in `CLAUDE.md`

Closes #5, closes #6

## Test plan
- [ ] Go to https://script.google.com → New Project
- [ ] Paste contents of `scripts/setup-google-sheet.gs`
- [ ] Run `setup()` function → authorize when prompted
- [ ] Verify alert dialog shows `GOOGLE_SHEET_ID`, `GOOGLE_DRIVE_FOLDER_ID`, `MASTER_SUMMARY_DOC_ID`
- [ ] Verify "Company Research Tracker" sheet exists with **Companies** tab (columns: Company Name, Ticker, Website, LinkedIn URL, Status, Last Researched) and **Leaders** tab (columns: Company, Name, Title, LinkedIn URL, Key Background, Talking Points, Date Found)
- [ ] Verify headers are bold and rows are frozen
- [ ] Verify "Company Research Docs" folder exists in Drive
- [ ] Verify "Weekly Research Summary" doc exists inside that folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)