### PR TITLE
Fix sheetName mode for workflow portability

### DIFF
--- a/workflow-research-pipeline.json
+++ b/workflow-research-pipeline.json
@@ -18,7 +18,7 @@
         "sheetName": {
           "__rl": true,
           "value": "Companies",
-          "mode": "list"
+          "mode": "name"
         },
         "event": "rowAdded"
       },
@@ -52,7 +52,7 @@
         "sheetName": {
           "__rl": true,
           "value": "Companies",
-          "mode": "list"
+          "mode": "name"
         }
       },
       "id": "read-all-companies",
@@ -396,7 +396,7 @@
         "sheetName": {
           "__rl": true,
           "value": "Leaders",
-          "mode": "list"
+          "mode": "name"
         },
         "columns": {
           "mappingMode": "defineBelow",
@@ -486,7 +486,7 @@
         "sheetName": {
           "__rl": true,
           "value": "Leaders",
-          "mode": "list"
+          "mode": "name"
         },
         "columns": {
           "mappingMode": "defineBelow",
@@ -559,7 +559,7 @@
         "sheetName": {
           "__rl": true,
           "value": "Companies",
-          "mode": "list"
+          "mode": "name"
         },
         "columns": {
           "mappingMode": "defineBelow",

--- a/workflow-weekly-report.json
+++ b/workflow-weekly-report.json
@@ -36,7 +36,7 @@
         "sheetName": {
           "__rl": true,
           "value": "Companies",
-          "mode": "list"
+          "mode": "name"
         }
       },
       "id": "read-companies",
@@ -234,7 +234,7 @@
         "sheetName": {
           "__rl": true,
           "value": "Leaders",
-          "mode": "list"
+          "mode": "name"
         },
         "filters": {
           "values": [
@@ -324,7 +324,7 @@
         "sheetName": {
           "__rl": true,
           "value": "Companies",
-          "mode": "list"
+          "mode": "name"
         },
         "columns": {
           "mappingMode": "defineBelow",
@@ -434,7 +434,7 @@
         "sheetName": {
           "__rl": true,
           "value": "Leaders",
-          "mode": "list"
+          "mode": "name"
         },
         "columns": {
           "mappingMode": "defineBelow",


### PR DESCRIPTION
## Summary
- Changes all `sheetName` resource locator entries from `"mode": "list"` to `"mode": "name"` in both workflow files
- Fixes "Sheet with ID Companies not found" error when importing workflows into a new n8n instance

Fixes #19

## Test plan
- [x] `node test-dry-run.js` — all 54 checks pass
- [ ] Re-import workflows into n8n and verify the Google Sheets Trigger no longer errors
- [ ] Verify Companies and Leaders tabs are correctly resolved by name

🤖 Generated with [Claude Code](https://claude.com/claude-code)